### PR TITLE
Resolve a permission denied when calling the plugin for Chat project

### DIFF
--- a/dotnet_desktop/generate_protos.bat
+++ b/dotnet_desktop/generate_protos.bat
@@ -42,6 +42,6 @@ set TOOLS_PATH=packages\Grpc.Tools.1.0.1\tools\windows_x64
 
 %TOOLS_PATH%\protoc.exe Chat\protos\chat.proto --csharp_out Chat 
 
-%TOOLS_PATH%\protoc.exe Chat\protos\chat.proto Chat Chat\protos\chat.proto --grpc_out Chat --plugin=protoc-gen-grpc=%TOOLS_PATH%\grpc_csharp_plugin.exe
+%TOOLS_PATH%\protoc.exe Chat\protos\chat.proto --grpc_out Chat --plugin=protoc-gen-grpc=%TOOLS_PATH%\grpc_csharp_plugin.exe
 
 endlocal


### PR DESCRIPTION
When running the batch file directly an error occurs.

```
~\src\grpc-samples-dotnet\dotnet_desktop>generate_protos.bat

~\src\grpc-samples-dotnet\dotnet_desktop>setlocal

~\src\grpc-samples-dotnet\dotnet_desktop>cd /d C:\Users\lucas.berger\src\grpc-samples-dotnet\dotnet_desktop\

~\src\grpc-samples-dotnet\dotnet_desktop>set TOOLS_PATH=packages\Grpc.Tools.1.0.1\tools\windows_x64

~\src\grpc-samples-dotnet\dotnet_desktop>packages\Grpc.Tools.1.0.1\tools\windows_x64\protoc.exe Greeter\protos\greeter.proto --csharp_out Greeter

~\grpc-samples-dotnet\dotnet_desktop>packages\Grpc.Tools.1.0.1\tools\windows_x64\protoc.exe Greeter\protos\greeter.proto --grpc_out Greeter --plugin=protoc-gen-grpc=packages\Grpc.Tools.1.0.1\tools\windows_x64\grpc
_csharp_plugin.exe

~\src\grpc-samples-dotnet\dotnet_desktop>packages\Grpc.Tools.1.0.1\tools\windows_x64\protoc.exe Chat\protos\chat.proto --csharp_out Chat

~\src\grpc-samples-dotnet\dotnet_desktop>packages\Grpc.Tools.1.0.1\tools\windows_x64\protoc.exe Chat\protos\chat.proto Chat Chat\protos\chat.proto --grpc_out Chat --plugin=protoc-gen-grpc=packages\Grpc.Tools.1.0.1\too
ls\windows_x64\grpc_csharp_plugin.exe
Chat: Permission denied

~\src\grpc-samples-dotnet\dotnet_desktop>endlocal

```

This change allows for the process to succeed.